### PR TITLE
To reduce CPU usage, create the array of demo items first then secondly assign the array to angular component

### DIFF
--- a/js/split-screen.js
+++ b/js/split-screen.js
@@ -64,9 +64,9 @@ function MyCtrl($scope, $filter) {
 
   $scope.MySelectedIndex = null;
   $scope.db = {};
-  $scope.db.items = [];
+  var items = [];
   for (var i = 0; i < 10000; i++) {
-    $scope.db.items.push(
+    items.push(
       {
         id: i + 1,
         name: {
@@ -80,6 +80,7 @@ function MyCtrl($scope, $filter) {
       }
     );
   }
+  $scope.db.items = items;
 
   $scope.db.dynamicColumns = [
     {value: 'item.id', title: 'ID'},


### PR DESCRIPTION
The CPU usage is high at startup due to the collection having elements added to it one by one while its bound to angular.