### PR TITLE
Make autocomplete options more robust and dynamically update when the source changes

### DIFF
--- a/src/directives/ngHandsontable.js
+++ b/src/directives/ngHandsontable.js
@@ -42,7 +42,7 @@ angular.module('ngHandsontable.directives', [])
               if (scope.htSettings.columns[i].type == 'autocomplete') {
                 if(typeof scope.htSettings.columns[i].optionList === 'string'){
                   var optionList = {};
-                  var match = scope.htSettings.columns[i].optionList.match(/^\s*(.+)\s+in\s+(.*)\s*$/);
+                  var match = scope.htSettings.columns[i].optionList.match(/^\s*([\s\S]+?)\s+in\s+([\s\S]+?)\s*$/);
                   if (match) {
                     optionList.property = match[1];
                     optionList.object = match[2];

--- a/src/directives/ngHandsontable.js
+++ b/src/directives/ngHandsontable.js
@@ -130,7 +130,7 @@ angular.module('ngHandsontable.directives', [])
             }
 
             var optionList = {};
-            var match = options.match(/^\s*(.+)\s+in\s+(.*)\s*$/);
+            var match = options.match(/^\s*([\s\S]+?)\s+in\s+([\s\S]+?)\s*$/);
             if (match) {
               optionList.property = match[1];
               optionList.object = match[2];

--- a/src/directives/ngHandsontable.js
+++ b/src/directives/ngHandsontable.js
@@ -52,7 +52,8 @@ angular.module('ngHandsontable.directives', [])
                   scope.htSettings.columns[i].optionList = optionList;
                 }
 
-                autoCompleteFactory.parseAutoComplete(scope.hotInstance, scope.htSettings.columns[i], scope.datarows, true);
+                // create the autocomplete options
+                autoCompleteFactory.parseAutoComplete(scope, i);
               }
             }
             scope.hotInstance.updateSettings(scope.htSettings);

--- a/src/services/settingFactory.js
+++ b/src/services/settingFactory.js
@@ -84,37 +84,44 @@ angular.module('ngHandsontable.services', [])
   ]
 )
   .factory('autoCompleteFactory', [
-    function () {
+    '$parse',
+    function ($parse) {
       return {
-        parseAutoComplete: function (instance, column, dataSet, propertyOnly) {
+        parseAutoComplete: function (scope, i) {
+          var column = scope.htSettings.columns[i];
           column.source = function (query, process) {
-            var row = instance.getSelected()[0];
-            var source = [];
-            var data = dataSet[row];
-
+            var row = scope.hotInstance.getSelected()[0];
+            var data = scope.datarows[row];
             if (data) {
               var options = column.optionList;
               if (options.object) {
                 if (angular.isArray(options.object)) {
-                  source = options.object;
+                  process(options.object);
                 } else {
-                  var objKeys = options.object.split('.')
-                    , paramObject = data;
-
-                  while (objKeys.length > 0) {
-                    var key = objKeys.shift();
-                    paramObject = paramObject[key];
-                  }
-
-                  if (propertyOnly) {
-                    for (var i = 0, length = paramObject.length; i < length; i++) {
-                      source.push(paramObject[i][options.property]);
-                    }
-                  } else {
-                    source = paramObject;
-                  }
+                  // I would normally just pass the string into $watchCollection,
+                  // but using the result of $parse allows us to evaluate the
+                  // expression against the row object, which is the only way to
+                  // parse the options correctly. ($parse supports filtering,
+                  // just like $watchCollection - $watchCollection actually uses
+                  // $parse behind the scenes.)
+                  var parsedExpr = $parse(options.object);
+                  scope.$watch('datarows['+row+']',
+                    function (datarow) {
+                      var collection = parsedExpr(datarow);
+                      var source = [];
+                      if (collection && collection.length) {
+                        for (var j = 0; j < collection.length; j++) {
+                          item = collection[j][options.property];
+                          if (item) {
+                            source.push(item);
+                          }
+                        }
+                      }
+                      process(source);
+                    },
+                    true // deep watch to pick up changes to options
+                  );
                 }
-                process(source);
               }
             }
           };

--- a/src/services/settingFactory.js
+++ b/src/services/settingFactory.js
@@ -105,20 +105,31 @@ angular.module('ngHandsontable.services', [])
                   // just like $watchCollection - $watchCollection actually uses
                   // $parse behind the scenes.)
                   var parsedExpr = $parse(options.object);
-                  scope.$watch('datarows['+row+']',
-                    function (datarow) {
-                      var collection = parsedExpr(datarow);
-                      var source = [];
-                      if (collection && collection.length) {
-                        for (var j = 0; j < collection.length; j++) {
-                          item = collection[j][options.property];
-                          if (item) {
-                            source.push(item);
-                          }
+
+                  var updateOptions = function (datarow) {
+                    var collection = parsedExpr(datarow);
+                    var source = [];
+                    if (collection && collection.length) {
+                      for (var j = 0; j < collection.length; j++) {
+                        item = collection[j][options.property];
+                        if (item) {
+                          source.push(item);
                         }
                       }
-                      process(source);
-                    },
+                    }
+                    process(source);
+                  };
+
+                  // set initial options
+                  // We have to call this function manually first. If we depend
+                  // on $watch to initialize the options, it will wait until
+                  // the end of the current execution stack to run it and thus
+                  // cause the autocomplete to be rendered without the options
+                  // the first time.
+                  updateOptions(data);
+
+                  scope.$watch('datarows['+row+']',
+                    updateOptions,
                     true // deep watch to pick up changes to options
                   );
                 }


### PR DESCRIPTION
Major changes include:
- use `$parse` to parse the value of the `datarows` attribute, which is much more robust and also allows for sorting and filtering the options (very similar to ngRepeat)
- deep watch on the row object so that if the options change the dropdowns will be updated accordingly
- `autocompleteFactory` now receives the entire `scope` object in order to support the above

Potential issues:
- ~~may be causing autocomplete cells to behave oddly~~ - fixed in 71b4c61
- the deep watches on the row objects may hurt performance
- watches may be duplicated or may not be cleared when rows are deleted - needs further testing to determine if any changes are necessary