### PR TITLE
Make autocomplete optionList more robust, including support for filters

### DIFF
--- a/src/directives/hotColumn.js
+++ b/src/directives/hotColumn.js
@@ -13,7 +13,7 @@
             $scope.column = {};
           }
           var optionList = {};
-          var match = options.match(/^\s*(.+)\s+in\s+(.*)\s*$/);
+          var match = options.match(/^\s*([\s\S]+?)\s+in\s+([\s\S]+?)\s*$/);
 
           if (match) {
             optionList.property = match[1];

--- a/src/directives/hotTable.js
+++ b/src/directives/hotTable.js
@@ -61,7 +61,7 @@
               }
               if (typeof scope.htSettings.columns[i].optionList === 'string') {
                 var optionList = {};
-                var match = scope.htSettings.columns[i].optionList.match(/^\s*(.+)\s+in\s+(.*)\s*$/);
+                var match = scope.htSettings.columns[i].optionList.match(/^\s*([\s\S]+?)\s+in\s+([\s\S]+?)\s*$/);
 
                 if (match) {
                   optionList.property = match[1];


### PR DESCRIPTION
Changes include:
- updated regex for parsing the value of the `datarows` attribute, based on the one used by the ngRepeat directive
- use `$parse` to parse the value of the `optionList.object`, which is much more robust and also allows for sorting and filtering the options (very similar to ngRepeat)

(These changes were originally made in #103, which was closed due to excessive merge conflicts with master.)