### PR TITLE
Updated breaking changes to Handsontable 0.34+ as mentioned issue #219

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /node_modules
 /bower_components
 dev.html
+.vscode

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "version": "0.13.0",
   "dependencies": {
     "angular": "^1.5.0",
-    "handsontable": "^0.28.0"
+    "handsontable": "^0.34.0"
   },
   "devDependencies": {
     "angular": "^1.5.0",

--- a/src/ngHandsontable.js
+++ b/src/ngHandsontable.js
@@ -6,5 +6,5 @@ angular.module('ngHandsontable', [
   ]);
 
 Handsontable.hooks.add('afterContextMenuShow', function() {
-  Handsontable.eventManager.isHotTableEnv = false;
+  Handsontable.EventManager.isHotTableEnv = false;
 });

--- a/test/directives/hotTable/watchingOptions.spec.js
+++ b/test/directives/hotTable/watchingOptions.spec.js
@@ -356,33 +356,6 @@ describe('hotTable - Watching options', function() {
     expect(scope.hotInstance.getSettings().autoWrapCol).toBe(rootScope.value);
   });
 
-  it('should create table with `copyRowsLimit` attribute', function() {
-    rootScope.value = 563;
-    var scope = angular.element(compile('<hot-table copy-rows-limit="value"></hot-table>')(rootScope)).isolateScope();
-
-    scope.$digest();
-
-    expect(scope.hotInstance.getSettings().copyRowsLimit).toBe(rootScope.value);
-  });
-
-  it('should create table with `copyColsLimit` attribute', function() {
-    rootScope.value = 563;
-    var scope = angular.element(compile('<hot-table copy-cols-limit="value"></hot-table>')(rootScope)).isolateScope();
-
-    scope.$digest();
-
-    expect(scope.hotInstance.getSettings().copyColsLimit).toBe(rootScope.value);
-  });
-
-  it('should create table with `pasteMode` attribute', function() {
-    rootScope.value = 'test';
-    var scope = angular.element(compile('<hot-table paste-mode="value"></hot-table>')(rootScope)).isolateScope();
-
-    scope.$digest();
-
-    expect(scope.hotInstance.getSettings().pasteMode).toBe(rootScope.value);
-  });
-
   it('should create table with `persistentState` attribute', function() {
     rootScope.value = true;
     var scope = angular.element(compile('<hot-table persistent-state="value"></hot-table>')(rootScope)).isolateScope();


### PR DESCRIPTION
Updated breaking changes to Handsontable 0.34+ as mentioned in https://github.com/handsontable/ngHandsontable/issues/219#issuecomment-334266247.

Removed irrelevant tests due to Copy/Paste refactoring in Handsontable 0.33+