### PR TITLE
Fix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ng-handsontable",
   "description": "AngularJS directive for Handsontable",
   "homepage": "https://github.com/handsontable/ngHandsontable",
+  "main": "dist/ngHandsontable.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/handsontable/ngHandsontable.git"


### PR DESCRIPTION
Because the package.json has no entry for `main`, it cannot be loaded by tools like webpack.
Fix ng-handsontable not being able to be imported in webpack.
Please merge and publish a minor update to npm