### PR TITLE
Fix memory leak

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "generate-release": "^0.10.2",
     "grunt": "~0.4.5",
     "grunt-browserify": "^4.0.0",
+    "grunt-cli": "^1.3.2",
     "grunt-contrib-concat": "^1.0.0",
     "grunt-contrib-jshint": "^1.0.0",
     "grunt-contrib-uglify": "^0.11.0",

--- a/src/directives/hotTable.js
+++ b/src/directives/hotTable.js
@@ -20,6 +20,10 @@
           settingFactory.updateHandsontableSettings($scope.hotInstance, $scope.htSettings);
         };
         this.removeColumnSetting = function(column) {
+          if (!$scope.hotInstance) {
+            return;
+          }
+
           if ($scope.htSettings.columns.indexOf(column) > -1) {
             $scope.htSettings.columns.splice($scope.htSettings.columns.indexOf(column), 1);
             settingFactory.updateHandsontableSettings($scope.hotInstance, $scope.htSettings);
@@ -146,6 +150,24 @@
               scope.htSettings.data = scope.datarows;
               settingFactory.updateHandsontableSettings(scope.hotInstance, scope.htSettings);
             }
+          });
+
+          function destroyInstance() {
+            if (scope.hotInstance) {
+              scope.hotInstance.destroy();
+              scope.hotInstance = null;
+              scope.htSettings = {};
+            }
+          }
+
+          // Destroy triggered by controller or scope destroying
+          scope.$on('$destroy', function() {
+            destroyInstance();
+          });
+
+          // Destroy triggered by DOM element removing
+          element.on('$destroy', function() {
+            destroyInstance();
           });
         };
       }

--- a/test/directives/hotTable.spec.js
+++ b/test/directives/hotTable.spec.js
@@ -14,12 +14,29 @@ describe('hotTable', function() {
     angular.element(document.querySelector('hot-table')).remove();
   });
 
-  it('should create Handsontable table', function() {
+  it('should create the Handsontable table', function() {
     var scope = angular.element(compile('<hot-table></hot-table>')(rootScope)).isolateScope();
 
     scope.$digest();
 
     expect(scope.hotInstance).toBeDefined();
+  });
+
+  it('should destroy the Handsontable table when the scope is destroyed', function() {
+    var scope = angular.element(compile('<hot-table></hot-table>')(rootScope)).isolateScope();
+
+    scope.$destroy();
+
+    expect(scope.hotInstance).toBeNull();
+  });
+
+  it('should destroy the Handsontable table when the DOM element is removed', function() {
+    var element = angular.element(compile('<hot-table></hot-table>')(rootScope));
+    var scope = element.isolateScope();
+
+    element.remove();
+
+    expect(scope.hotInstance).toBeNull();
   });
 
   it('should re-render table after datarows change', function(done) {


### PR DESCRIPTION
This PR fixes a memory leak caused by lack of the Handsontable instance destroying on scope destroying or DOM element removing.

Issue: #157