### PR TITLE
Add support for Handsontable v8

### DIFF
--- a/src/services/settingFactory.js
+++ b/src/services/settingFactory.js
@@ -214,7 +214,14 @@
        * @returns {Array}
        */
       getAvailableSettings: function(hyphenateStyle) {
-        var settings = Object.keys(Handsontable.DefaultSettings.prototype);
+        var defaultSettings = Handsontable.DefaultSettings.prototype;
+
+        // For Handsontable v8 the prototype is `undefined`.
+        if (defaultSettings === void 0) {
+          defaultSettings = Handsontable.DefaultSettings;
+        }
+
+        var settings = Object.keys(defaultSettings);
 
         if (settings.indexOf('contextMenuCopyPaste') === -1) {
           settings.push('contextMenuCopyPaste');


### PR DESCRIPTION
Add support for Handsontable v8. The `DefaultSettings` in v8 changed its shape, for v8 there is no reason to use a prototype.

This PR is backward compatible with the older Handsontable versions.